### PR TITLE
Reuse vecs

### DIFF
--- a/tiling/src/constellation.rs
+++ b/tiling/src/constellation.rs
@@ -182,7 +182,8 @@ pub trait Constellation {
         points: &BTreeSet<IntersectionPoint>,
         plane: &FiveFold,
         boundaries: Option<&[IntersectionPoint]>,
-    ) -> Vec<Self>
+        constellations: &mut Vec<Self>
+    )
     where
         Self: Sized,
     {
@@ -217,8 +218,6 @@ pub trait Constellation {
             pair_scan(points, Self::delta())
         };
 
-        let mut constellations = Vec::new();
-
         for (primary, secondary) in pairs
             .iter()
             .flat_map(|(primary, secondaries)| once(primary).cartesian_product(secondaries.iter()))
@@ -229,8 +228,6 @@ pub trait Constellation {
                 constellations.push(found);
             }
         }
-
-        constellations
     }
 }
 

--- a/tiling/src/fivefold.rs
+++ b/tiling/src/fivefold.rs
@@ -111,7 +111,7 @@ fn bar_to_point(ms: &MusicalSequence, bar: BarNumber) -> Point2D<f64> {
     distance_to_point(ms, ms.get_bar_distance(bar))
 }
 
-fn bars(area: &Box2D<f64>, ms: &MusicalSequence, forced: bool) -> Vec<BarNumber> {
+fn bars<'a>(area: &Box2D<f64>, ms: &'a MusicalSequence, forced: bool) -> impl Iterator<Item = BarNumber> + Clone + 'a {
     let (first, last) = [area.min.x, area.max.x]
         .iter()
         .copied()
@@ -124,14 +124,17 @@ fn bars(area: &Box2D<f64>, ms: &MusicalSequence, forced: bool) -> Vec<BarNumber>
 
     let bars = ms.get_bar(first)..=ms.get_bar(last);
 
-    if forced {
-        ms.forced_bars(bars)
-    } else {
-        ms.unforced_bars(bars)
-    }
+    bars.filter(move |&i| {
+        // we pray to the branch prediction and inlining gods here
+        if forced {
+            ms.is_forced(i)
+        } else {
+            !ms.is_forced(i)
+        }
+    })
 }
 
-fn forced_bars(area: &Box2D<f64>, ms: &MusicalSequence) -> Vec<BarNumber> {
+fn forced_bars<'a>(area: &Box2D<f64>, ms: &'a MusicalSequence) -> impl Iterator<Item = BarNumber> + Clone + 'a {
     bars(area, ms, true)
 }
 

--- a/tiling/src/lib.rs
+++ b/tiling/src/lib.rs
@@ -49,14 +49,17 @@ fn force_new<T: Constellation + Sized>(plane: &mut FiveFold, constellations: &Ve
 }
 
 pub fn compute_area(plane: &mut FiveFold, bounds: &Box2D<f64>) -> MatchList {
-    let kites;
-    let mut darts;
-    let mut double_kites;
+    let mut darts = Vec::new();
+    let mut double_kites = Vec::new();
+    let mut boundaries = Vec::new();
 
     let (points, boundaries) = loop {
+        darts.clear();
+        double_kites.clear();
+        boundaries.clear();
+
         let points = plane.intersection_points(bounds);
 
-        let mut boundaries = Vec::new();
         let mut layer = -1f64;
         let mut theta = -1f64;
 
@@ -69,15 +72,16 @@ pub fn compute_area(plane: &mut FiveFold, bounds: &Box2D<f64>) -> MatchList {
             }
         }
 
-        darts = Dart::constellations(&points, plane, Some(&boundaries));
-        double_kites = DoubleKite::constellations(&points, plane, Some(&boundaries));
+        Dart::constellations(&points, plane, Some(&boundaries), &mut darts);
+        DoubleKite::constellations(&points, plane, Some(&boundaries), &mut double_kites);
 
         if !(force_new(plane, &darts) || force_new(plane, &double_kites)) {
             break (points, boundaries);
         }
     };
 
-    kites = Kite::constellations(&points, plane, Some(&boundaries));
+    let mut kites = Vec::new();
+    Kite::constellations(&points, plane, Some(&boundaries), &mut kites);
 
     MatchList { kites, darts }
 }

--- a/tiling/src/musical_sequence.rs
+++ b/tiling/src/musical_sequence.rs
@@ -190,20 +190,6 @@ impl MusicalSequence {
         }
     }
 
-    pub(crate) fn unforced_bars<I>(&self, r: I) -> Vec<BarNumber>
-    where
-        I: Iterator<Item = BarNumber>,
-    {
-        r.filter(|&i| !self.is_forced(i)).collect_vec()
-    }
-
-    pub(crate) fn forced_bars<I>(&self, r: I) -> Vec<BarNumber>
-    where
-        I: Iterator<Item = BarNumber>,
-    {
-        r.filter(|&i| self.is_forced(i)).collect_vec()
-    }
-
     pub fn get_bar_forcings<I>(&self, r: I) -> Vec<bool>
     where
         I: Iterator<Item = BarNumber>,


### PR DESCRIPTION
We shouldn't allocate and deallocate vecs in a loop (we can just clear the length and preserve the capacity of the backing allocation).