### PR TITLE
adios cartesian product

### DIFF
--- a/tiling/src/constellation.rs
+++ b/tiling/src/constellation.rs
@@ -221,7 +221,7 @@ pub trait Constellation {
 
         for (primary, secondary) in pairs
             .iter()
-            .flat_map(|(primary, secondaries)| once(primary).cartesian_product(secondaries.iter()))
+            .flat_map(|(primary, secondaries)| secondaries.iter().map(move |s| (primary, s)))
         {
             if let Some(found) = Self::test_pair(points, plane, [primary, secondary]) {
                 constellations.push(found);


### PR DESCRIPTION
The first iterator is always a single item, so we can just map over the second one and avoid going through the `cartesian_product()` machinery.